### PR TITLE
UF-15109 - Health check for scheduled workers

### DIFF
--- a/src/main/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSource.java
+++ b/src/main/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSource.java
@@ -31,6 +31,7 @@ public class ConfluenceDataSource {
 	private final Map<String, ConfluenceWorker> workers = new HashMap<>();
 
 	ConfluenceDataSource(final ConfluenceIntegrationProperties properties,
+		final ConfluenceDataSourceHealthIndicator healthIndicator,
 		final ConfluenceClientRegistry confluenceClientRegistry,
 		final ConfluencePageMapper confluencePageMapper,
 		final DbIntegration dbIntegration,
@@ -42,7 +43,7 @@ public class ConfluenceDataSource {
 
 		properties.environments().forEach((municipalityId, environment) -> {
 			// Create a worker for the current environment
-			var worker = new ConfluenceWorker(municipalityId, properties, confluenceClientRegistry, confluencePageMapper, intricIntegration, dbIntegration, pageJsonParser);
+			var worker = new ConfluenceWorker(municipalityId, properties, healthIndicator, confluenceClientRegistry, confluencePageMapper, intricIntegration, dbIntegration, pageJsonParser);
 			// "Cache" the worker
 			workers.put(municipalityId, worker);
 

--- a/src/main/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceHealthIndicator.java
+++ b/src/main/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceHealthIndicator.java
@@ -1,0 +1,45 @@
+package se.sundsvall.intricdatacollector.datasource.confluence;
+
+import static java.util.Optional.ofNullable;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+class ConfluenceDataSourceHealthIndicator implements HealthIndicator {
+
+	static final Status RESTRICTED = new Status("RESTRICTED");
+	static final String REASON = "Reason";
+	static final String UNKNOWN_REASON = "Unknown";
+
+	private Health health = Health.up().build();
+
+	@Override
+	public Health health() {
+		return health;
+	}
+
+	boolean isHealthy() {
+		return health().getStatus().equals(Status.UP);
+	}
+
+	void reset() {
+		setHealthy();
+	}
+
+	void setHealthy() {
+		health = Health.up().build();
+	}
+
+	void setUnhealthy() {
+		setUnhealthy(null);
+	}
+
+	void setUnhealthy(final String detail) {
+		health = Health.status(RESTRICTED)
+			.withDetail(REASON, ofNullable(detail).orElse(UNKNOWN_REASON))
+			.build();
+	}
+}

--- a/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceHealthIndicatorTests.java
+++ b/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceHealthIndicatorTests.java
@@ -1,0 +1,88 @@
+package se.sundsvall.intricdatacollector.datasource.confluence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.actuate.health.Status.DOWN;
+import static org.springframework.boot.actuate.health.Status.OUT_OF_SERVICE;
+import static org.springframework.boot.actuate.health.Status.UNKNOWN;
+import static org.springframework.boot.actuate.health.Status.UP;
+import static se.sundsvall.intricdatacollector.datasource.confluence.ConfluenceDataSourceHealthIndicator.REASON;
+import static se.sundsvall.intricdatacollector.datasource.confluence.ConfluenceDataSourceHealthIndicator.RESTRICTED;
+import static se.sundsvall.intricdatacollector.datasource.confluence.ConfluenceDataSourceHealthIndicator.UNKNOWN_REASON;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+class ConfluenceDataSourceHealthIndicatorTests {
+
+	private final ConfluenceDataSourceHealthIndicator healthIndicator = new ConfluenceDataSourceHealthIndicator();
+
+	@Test
+	void healthIsCreatedWithStatusUpWhenHealthIndicatorIsCreated() {
+		assertThat(healthIndicator.health()).isNotNull();
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(UP);
+	}
+
+	@ParameterizedTest
+	@MethodSource("argumentsForIsHealthy")
+	void isHealthy(final Status status, final boolean expectedResult) {
+		var healthMock = mock(Health.class);
+		when(healthMock.getStatus()).thenReturn(status);
+		var healthIndicatorSpy = spy(healthIndicator);
+		when(healthIndicatorSpy.health()).thenReturn(healthMock);
+
+		assertThat(healthIndicatorSpy.isHealthy()).isEqualTo(expectedResult);
+	}
+
+	static Stream<Arguments> argumentsForIsHealthy() {
+		return Stream.of(
+			Arguments.of(UP, true),
+			Arguments.of(DOWN, false),
+			Arguments.of(OUT_OF_SERVICE, false),
+			Arguments.of(UNKNOWN, false),
+			Arguments.of(RESTRICTED, false));
+	}
+
+	@Test
+	void resetSetsStatusToUp() {
+		healthIndicator.reset();
+
+		assertThat(healthIndicator.health()).isNotNull();
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(UP);
+	}
+
+	@Test
+	void setHealthySetsStatusToUp() {
+		healthIndicator.setHealthy();
+
+		assertThat(healthIndicator.health()).isNotNull();
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(UP);
+	}
+
+	@Test
+	void setUnhealthy() {
+		healthIndicator.setUnhealthy();
+
+		assertThat(healthIndicator.health()).isNotNull();
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(RESTRICTED);
+		assertThat(healthIndicator.health().getDetails()).containsEntry(REASON, UNKNOWN_REASON);
+	}
+
+	@Test
+	void setUnhealthyWithDetail() {
+		var detail = "someDetail";
+
+		healthIndicator.setUnhealthy(detail);
+
+		assertThat(healthIndicator.health()).isNotNull();
+		assertThat(healthIndicator.health().getStatus()).isEqualTo(RESTRICTED);
+		assertThat(healthIndicator.health().getDetails()).containsEntry(REASON, detail);
+	}
+}

--- a/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceTests.java
+++ b/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceDataSourceTests.java
@@ -40,6 +40,8 @@ class ConfluenceDataSourceTests {
 	@Mock
 	private ConfluenceIntegrationProperties propertiesMock;
 	@Mock
+	private ConfluenceDataSourceHealthIndicator workerHealthIndicatorMock;
+	@Mock
 	private Map<String, ConfluenceIntegrationProperties.Environment> environmentsMock;
 	@Mock
 	private ConfluenceIntegrationProperties.Environment environmentMock1;
@@ -86,7 +88,7 @@ class ConfluenceDataSourceTests {
 	}
 
 	private ConfluenceDataSource createDataSource() {
-		return new ConfluenceDataSource(propertiesMock, confluenceClientRegistryMock, confluencePageMapperMock,
+		return new ConfluenceDataSource(propertiesMock, workerHealthIndicatorMock, confluenceClientRegistryMock, confluencePageMapperMock,
 			dbIntegrationMock, intricIntegrationMock, pageJsonParserMock, taskSchedulerMock, lockProviderMock);
 	}
 

--- a/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceWorkerTests.java
+++ b/src/test/java/se/sundsvall/intricdatacollector/datasource/confluence/ConfluenceWorkerTests.java
@@ -41,6 +41,8 @@ class ConfluenceWorkerTests {
 	private static final String INTRIC_GROUP_ID = "someIntricGroupId";
 
 	@Mock
+	private ConfluenceDataSourceHealthIndicator healthIndicatorMock;
+	@Mock
 	private ConfluenceIntegrationProperties propertiesMock;
 	@Mock
 	private ConfluenceIntegrationProperties.Environment environmentMock;
@@ -73,7 +75,7 @@ class ConfluenceWorkerTests {
 
 		when(confluenceClientRegistryMock.getClient(MUNICIPALITY_ID)).thenReturn(confluenceClientMock);
 
-		worker = new ConfluenceWorker(MUNICIPALITY_ID, propertiesMock, confluenceClientRegistryMock, pageMapperMock, intricIntegrationMock, dbIntegrationMock, pageJsonParserMock);
+		worker = new ConfluenceWorker(MUNICIPALITY_ID, propertiesMock, healthIndicatorMock, confluenceClientRegistryMock, pageMapperMock, intricIntegrationMock, dbIntegrationMock, pageJsonParserMock);
 	}
 
 	@Test


### PR DESCRIPTION
Adds a health indicator for the Confluence datasource that is updated by the workers as they succeed or fail

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
